### PR TITLE
fix: render codeblock correctly

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const path = require('path');
 const pkg = require('./package.json');
 
-hexo.extend.tag.register('insertmd', function(args){
+hexo.extend.tag.register('insertmd', async (args) => {
   const [filePath] = args;
   const file = path.join(hexo.source_dir, filePath);
 
@@ -10,7 +10,6 @@ hexo.extend.tag.register('insertmd', function(args){
     throw new Error(`[${pkg.name}] File "${file}" does not exist.`);
   }
 
-  return hexo.render.renderSync({
-    path: file
-  });
-});
+  const result = await hexo.post.render(source = file)
+  return result.content;
+}, {async: true});


### PR DESCRIPTION
@bennycode 

This is a solution for below issues.

* https://github.com/hexojs/hexo-renderer-marked/issues/190
* https://github.com/hexojs/hexo/issues/4708

I confirmed this source code works well on my local machine.
Would you please check this?

```sh
# My local machine environment is....

hexo: 5.4.0
hexo-cli: 4.2.0
os: Windows_NT 10.0.19041 win32 x64
node: 16.1.0
v8: 9.0.257.24-node.11
```

Thank you :)